### PR TITLE
Release of stable v1.0.0 + Added documentation / content

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,70 @@
-# search-ui
-Search user interface with headless
+# Project: Search UI
 
-## Getting started
+Purpose of this repository is to provide MWS pages with the proper JS and CSS assets to achieve a working search page with the vendor's (Coveo) technology called Headless.
 
-1. run: npm install -g grunt-cli
-2. run: npm install
-3. run: grunt (build script; tasks to lint, test & minify content in "dist")
-4. To test web pages: Push to GitHub and run your GitHub Pages
-5. To Deploy: Take the content of the "dist" folder and put it on a server
+## References
 
-## Versioning API
+- Coveo Headless: https://docs.coveo.com/en/headless/latest/
+
+## Key details
+
+### Sponsor / Contact
+
+This project is led by Principal Publisher at ESDC. The key contact in case of questions related to the project is Francis Gorman, who can be reached at francis.gorman@hrsdc-rhdcc.gc.ca. If no reply is received from this person, fallback contact is ESDC.SD.DEV-DEV.DS.EDSC@servicecanada.gc.ca.
+
+### Timeline and frequency
+
+The goal is to continue to refine and improve this code base on a regular basis. Every 6 months, if no activity is recorded on this repository, the key contact shall be reached out to in order to ensure it isn't stale.
+
+**Removal date** will coincide with end of contract with vendor.
+
+### Improvement plan
+
+To manage development activities related to this project, a standard internal issue tracking system used at Principal Publisher will be used. Also, regular touchpoints with the search vendor, as well as formal service requests entered through their portal, could also spark some development activities from a vendor perspective.
+
+In the medium to long term, some activities may take place related to:
+- stabilization of the query suggestion combobox;
+- porting of some parts of the codebase to GCWeb;
+- addition of machine learning features.
+
+## Releases and API
+
+All changes contributed through Pull requests will be packaged as releases. Releases are completed through the "Releases" tab in this GitHub repository; then, deployment to MWS follows the reguar release management cycle accordingly.
 
 Each new verion of this project is defined based on an evaluaton of the impacts of changes against any formerly up-to-date Search UI implementation. The scope constitutes of all files within the "dist" folder (distribution files), which are JavaScript scripts and CSS styles.
 
 Search UI follows [Semantic Versioning 2.0.0](https://semver.org/)
+
+---
+
+## To do
+
+[Consult full checklist of to do items](todo.md)
+
+---
+
+## Getting started
+
+This rubric is for developers
+
+### Build files
+
+1. run: npm install -g grunt-cli
+2. run: npm install
+3. run: grunt (build script; tasks to lint, test & minify content in "dist")
+
+### Test as end-user
+
+1. Push to a branch in your origin remote, in a branch of your choice. It is recommended that you use a dedicated branch for testing, which is different from one where you would be opening a Pull request from.
+2. Make sure your repository has GitHub Pages enabled, on that specific above-mentioned branch.
+3. Since you need a token to communicate with the Coveo API, you can do the following to go to get a token valid for 24 hrs:
+    1. Go to a search page on the Canada.ca preview such as: **/en/sr/srb.html**.
+    2. Open the inspector (developer tool) and look for the `div` tag that has the attribute called `data-gc-search`.
+    3. Inside this attribute, you'll find a Javascript object that has a field called `accessToken`. Grab the value of that token.
+    4. Replace `XYZ` with the token on any page within the /test/ folder of this project, such as **srb-en.html**.
+    5. If you are planning on opening a pull request with your changes, do not forget to put `XYZ` back into the files.
+    6. If the token doesn't seem valid, take another one from the Canada.ca Preview server or you may have passed the 24 hours TTL of the token; get another one.
+
+### Deployment
+
+1. Take the content of the "dist" folder and put it on a server. Make sure you have a mechanism in place to handle a key/token

--- a/index.html
+++ b/index.html
@@ -8,7 +8,9 @@ title: Search user interface (UI) with Headless
 
 <ul>
 	<li><a href="test/srb-en.html">Sample basic search page</a></li>
-	<!--<li><a href="test/src-en.html">Sample contextual search page</a></li>-->
+	<li><a href="test/sra-en.html">Sample advanced search page</a></li>
+	<li><a href="test/src-en.html">Sample contextual search page</a></li>
 	<li><a href="test/srb-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (base)</a></li>
-	<!--<li><a href="test/src-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (contextuelle)</a></li>-->
+	<li><a href="test/sra-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (avancée)</a></li>
+	<li><a href="test/src-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (contextuelle)</a></li>
 </ul>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "search-ui",
-	"version": "1.0.0-alpha",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "search-ui",
-	"version": "1.0.0-alpha",
+	"version": "1.0.0",
 	"description": "Canada.ca Search UI with Headless",
 	"main": "index.html",
 	"repository": {

--- a/src/connector.js
+++ b/src/connector.js
@@ -212,8 +212,8 @@ function initTpl() {
 		if ( lang === "fr" ) {
 			resultErrorTemplateHTML = 
 				`<section class="alert alert-warning">
-					<h2>The Canada.ca Search is currently experiencing issues</h2>
-					<p>A resolution for the restoration is presently being worked.	We apologize for any inconvenience.</p>
+					<h2>Nous éprouvons actuellement des problèmes avec la fonction de recherche sur le site Web Canada.ca</h2>
+					<p>L'équipe chargée de rétablir les services touchés travaille de façon à résoudre le problème aussi rapidement que possible. Nous vous prions de nous excuser pour tout inconvénient.</p>
 				</section>`;
 		}
 		else {
@@ -228,22 +228,22 @@ function initTpl() {
 	if ( !querySummaryTemplateHTML ) {
 		if ( lang === "fr" ) {
 			querySummaryTemplateHTML = 
-				`<h2><span class="wb-inv">Résultats de recherche - </span><span role="status">%[numberOfResults] résultats de recherche pour "%[query]"</span></h2>`;
+				`<h2>%[numberOfResults] résultats de recherche pour "%[query]"</h2>`;
 		}
 		else {
 			querySummaryTemplateHTML = 
-				`<h2><span class="wb-inv">Search results - </span><span role="status">%[numberOfResults] search results for "%[query]"</span></h2>`;
+				`<h2>%[numberOfResults] search results for "%[query]"</h2>`;
 		}
 	}
 
 	if ( !didYouMeanTemplateHTML ) {
 		if ( lang === "fr" ) {
 			didYouMeanTemplateHTML = 
-				`<p class="did-you-mean">Rechercher plutôt <button class="btn-link p-0">%[correctedQuery]</button> ?</p>`;
+				`<p class="h5 mrgn-lft-md">Rechercher plutôt <button class="btn btn-link p-0" type="button">%[correctedQuery]</button> ?</p>`;
 		}
 		else {
 			didYouMeanTemplateHTML = 
-				`<p class="h5 mrgn-lft-md">Did you mean <button class="btn-link p-0">%[correctedQuery]</button> ?</p>`;
+				`<p class="h5 mrgn-lft-md">Did you mean <button class="btn btn-link p-0" type="button">%[correctedQuery]</button> ?</p>`;
 		}
 	}
 
@@ -361,8 +361,6 @@ function initTpl() {
 		searchBoxElement.after( suggestionsElement );
 	}
 
-	resultsSection.setAttribute( "aria-live", "polite" );
-
 	// Query suggestions
 	if ( suggestionsElement ) {
 
@@ -399,6 +397,9 @@ function initTpl() {
 			} );
 		}
 	}
+
+	// Now that the templates are iniated, update the user when idle of further change to the region
+	resultsSection.setAttribute( "aria-live", "polite" );
 }
 
 // Initiate headless engine
@@ -421,7 +422,7 @@ function initEngine() {
 						requestContent.originLevel3 = params.originLevel3;
 						request.body = JSON.stringify( requestContent );
 
-
+						// Event used to expose a data layer when search events occur; useful for analytics
 						const searchEvent = new CustomEvent( "searchEvent", { detail: requestContent } );
 						document.dispatchEvent( searchEvent );
 					}
@@ -530,6 +531,7 @@ function initEngine() {
 			headlessEngine.dispatch( sortAction );
 		}
 
+		// Specifically for Elections Canada, allows to search within scope
 		if ( urlParams.elctn_cat ) {
 			let elctn_cat = urlParams.elctn_cat.toLowerCase();
 			if( elctn_cat === "his" ) {
@@ -764,11 +766,6 @@ function updateSearchBoxState( newState ) {
 	}
 }
 
-// Scroll to top
-function scrollToTop() {
-	querySummaryElement.scrollIntoView();
-}
-
 // Filters out dangerous URIs that can create XSS attacks such as `javascript:`.
 function filterProtocol( uri ) {
 
@@ -875,6 +872,7 @@ function updateResultListState( newState ) {
 	}
 	else if ( resultListState.firstSearchExecuted && !resultListState.hasResults && !resultListState.hasError ) {
 		resultListElement.innerHTML = noResultTemplateHTML;
+		focusToView();
 	}
 }
 
@@ -901,6 +899,21 @@ function updateQuerySummaryState( newState ) {
 		querySummaryElement.textContent = "";
 		querySummaryElement.innerHTML = resultErrorTemplateHTML;
 	}
+
+	
+	if( !querySummaryState.isLoading && querySummaryElement.textContent !== "" ) {
+		focusToView();
+	}
+}
+
+// Focus to H2 heading in results section
+function focusToView() {
+	let focusElement = resultsSection.querySelector( "h2" );
+
+	if( focusElement ) {
+		focusElement.tabIndex = -1;
+		focusElement.focus();
+	}
 }
 
 // update did you mean
@@ -918,7 +931,6 @@ function updateDidYouMeanState( newState ) {
 			buttonNode.onclick = ( e ) => { 
 				updateSearchBoxFromState = true;
 				didYouMeanController.applyCorrection();
-				scrollToTop();
 				e.preventDefault();
 			};
 		}
@@ -939,7 +951,6 @@ function updatePagerState( newState ) {
 
 		buttonNode.onclick = () => { 
 			pagerController.previousPage();
-			scrollToTop();
 		};
 
 		pagerElement.appendChild( liNode );
@@ -951,9 +962,9 @@ function updatePagerState( newState ) {
 
 		liNode.innerHTML = pageTemplateHTML.replaceAll( '%[page]', pageNo );
 
-		if ( page < pagerState.currentPage - 1 || page > pagerState.currentPage + 1 ) {
+		if ( pagerState.currentPage - 1 > page || page > pagerState.currentPage + 1 ) {
 			liNode.classList.add( 'hidden-xs', 'hidden-sm' );
-			if ( page < pagerState.currentPage - 2 || page > pagerState.currentPage + 2 ) {
+			if ( pagerState.currentPage - 2 > page || page > pagerState.currentPage + 2 ) {
 				liNode.classList.add( 'hidden-md' );
 			}
 		}
@@ -967,7 +978,6 @@ function updatePagerState( newState ) {
 
 		buttonNode.onclick = () => {
 			pagerController.selectPage( pageNo );
-			scrollToTop();
 		};
 
 		pagerElement.appendChild( liNode );
@@ -982,7 +992,6 @@ function updatePagerState( newState ) {
 
 		buttonNode.onclick = () => { 
 			pagerController.nextPage(); 
-			scrollToTop();
 		};
 
 		pagerElement.appendChild( liNode );

--- a/test/sra-en.html
+++ b/test/sra-en.html
@@ -1,0 +1,80 @@
+---
+title: Advanced search page for Governement of Canada using Headless
+description: Demo page for the Canada.ca Search UI Advanced
+lang: en
+altLangPage: sra-fr.html
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2024-05-29
+stylesheets:
+    - href: "../src/connector.css"
+---
+
+<!--FORM-->
+<form action="#wb-land" method="get">  
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Find pages with...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon1">all these words:</label> 
+			<input name="allq" class="form-control" id="advseacon1" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon2">this exact word or phrase:</label> 
+			<input name="exctq" class="form-control" id="advseacon2" maxlength="200" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon3">any of these words:</label> 
+			<input name="anyq" class="form-control" id="advseacon3" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon4">none of these words:</label> 
+			<input name="noneq" class="form-control" id="advseacon4" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div>
+		<p id="gc-pi" class="mrgn-tp-md">Don’t include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+	</fieldset> 
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Then narrow your results by...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon5">pages updated:</label> 
+			<select class="form-control" name="fqupdate" id="advseacon5" data-fusion-query="safe"> <option selected="" value="">anytime</option> <option value="dateModified_dt:[NOW-1DAY TO NOW]">past 24 hours</option> <option value="dateModified_dt:[NOW-7DAYS TO NOW]">past week</option> <option value="dateModified_dt:[NOW-1MONTH TO NOW]">past month</option> <option value="dateModified_dt:[NOW-1YEAR TO NOW]">past year</option> </select> 
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon7">site or domain:</label> 
+			<input name="dmn" class="form-control" id="advseacon7" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon8">terms appearing:</label> 
+			<select class="form-control" name="fqocct" id="advseacon8" data-fusion-query="safe"> <option value="">anywhere in the page</option> <option value="title_t">in the title of the page</option> <option value="url_t">in the URL of the page</option> <option value="body_t">in the body of the page </option></select> 
+		</div> 
+	</fieldset> 
+	<button type="submit" class="btn btn-md btn-primary">Search</button> 
+</form> 
+<div class="row mrgn-tp-md"> 
+	<div class="col-md-2"> 
+		<a href="srb-en.html">Basic search</a> 
+	</div> 
+	<div class="col-md-2"> 
+		<a href="https://www.canada.ca/en/sr/st.html">Search tips</a> 
+	</div> 
+</div>
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"XYZ",
+	"isAdvancedSearch": true
+}'></div>
+
+<!--DEMO-EXPECTATIONS-->
+<h2>Expected output for the result section</h2>
+<details>
+	<summary>Output for Results section</summary>
+	[To be completed, see Connector.js for reference until then]
+</details>
+
+<!--SCRIPT-->
+<script type="module" src="../src/connector.js"></script>

--- a/test/sra-fr.html
+++ b/test/sra-fr.html
@@ -1,0 +1,80 @@
+---
+title: Résultats de la recherche (avancée) pour le gouvernement du Canada avec Headless
+description: Page démo pour l'interface utilisateur de recherche Canada.ca (avancée)
+lang: fr
+altLangPage: sra-en.html
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2024-05-29
+stylesheets:
+    - href: "../src/connector.css"
+---
+
+<!--FORM-->
+<form action="#wb-land" method="get">  
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Trouvez des pages avec…</legend> 
+		<div class="form-group"> 
+		<label for="advseacon1">tous les mots suivants :</label> 
+		<input name="allq" class="form-control" id="advseacon1" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<div class="form-group"> 
+		<label for="advseacon2">ce mot ou groupe de mots exact :</label> 
+		<input name="exctq" class="form-control" id="advseacon2" maxlength="200" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<div class="form-group"> 
+		<label for="advseacon3">l'un des mots suivants :</label> 
+		<input name="anyq" class="form-control" id="advseacon3" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<div class="form-group"> 
+		<label for="advseacon4">aucun des mots suivants :</label> 
+		<input name="noneq" class="form-control" id="advseacon4" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<p id="gc-pi" class="mrgn-tp-md">N'incluez pas de renseignements personnels (téléphone, courriel, NAS, renseignements financiers, médicaux ou professionnels).</p>
+	</fieldset> 
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Affinez ensuite la recherche par…</legend> 
+		<div class="form-group"> 
+			<label for="advseacon5">dernière mise à jour :</label> 
+			<select class="form-control" name="fqupdate" id="advseacon5" data-fusion-query="safe"> <option selected="" value=""> à une date indifférente </option> <option value="dateModified_dt:[NOW-1DAY TO NOW]"> au cours des dernières 24 heures </option> <option value="dateModified_dt:[NOW-7DAYS TO NOW]"> au cours des 7 derniers jours </option> <option value="dateModified_dt:[NOW-1MONTH TO NOW]"> au cours des 31 derniers jours </option> <option value="dateModified_dt:[NOW-1YEAR TO NOW]"> au cours des 365 derniers jours </option> </select> 
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon7">site ou domaine :</label> 
+			<input name="dmn" class="form-control" id="advseacon7" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		</div> 
+		<div class="form-group"> 
+			<label for="advseacon8">termes paraissant :</label> 
+			<select class="form-control" name="fqocct" id="advseacon8" data-fusion-query="safe"> <option value="" n'importe où dans la page </option> <option value="title_t"> dans le titre de la page </option> <option value="url_t">dans l'URL de la page </option> <option value="body_t">dans le corps de la page </option> </select> 
+		</div> 
+	</fieldset> 
+	<button type="submit" class="btn btn-md btn-primary">Recherche</button> 
+</form> 
+<div class="row mrgn-tp-md"> 
+	<div class="col-md-2"> 
+		<a href="srb-fr.html">Recherche de base</a> 
+	</div> 
+	<div class="col-md-2"> 
+		<a href="https://www.canada.ca/fr/sr/tr.html">Trucs de recherche</a> 
+	</div> 
+</div>
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"XYZ",
+	"isAdvancedSearch": true
+}'></div>
+
+<!--DEMO-EXPECTATIONS-->
+<h2>Section Résultats attendu pour la section de résultats</h2>
+<details>
+	<summary>Section Résultats générée</summary>
+	[À compléter, voir Connector.js comme référence pour l'instant]
+</details>
+
+<!--SCRIPT-->
+<script type="module" src="../src/connector.js"></script>

--- a/test/srb-en.html
+++ b/test/srb-en.html
@@ -1,5 +1,5 @@
 ---
-title: Basic search Page for Governement of Canada using Headless
+title: Basic search page for Governement of Canada using Headless
 description: Demo page for the Canada.ca Search UI Basic
 lang: en
 altLangPage: srb-fr.html
@@ -31,7 +31,7 @@ stylesheets:
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
 	"accessToken":"XYZ"
 }'></div>
-<p class="text-center small"><a href="https://www.canada.ca/en/sr/srb/sra.html">Perform an advanced search</a></p>
+<p class="text-center small"><a href="sra-en.html">Perform an advanced search</a></p>
 
 <!--DEMO-EXPECTATIONS-->
 <h2>Expected output for the result section</h2>

--- a/test/srb-fr.html
+++ b/test/srb-fr.html
@@ -31,7 +31,7 @@ stylesheets:
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
 	"accessToken":"XYZ"
 }'></div>
-<p class="text-center small"><a href="https://www.canada.ca/fr/sr/srb/sra.html">Effectuer une recherche avancée</a></p>
+<p class="text-center small"><a href="sra-fr.html">Effectuer une recherche avancée</a></p>
 
 <!--DEMO-EXPECTATIONS-->
 <h2>Section Résultats attendu pour la section de résultats</h2>

--- a/test/src-en.html
+++ b/test/src-en.html
@@ -1,0 +1,53 @@
+---
+title: Contextual search page (ESDC) for Governement of Canada using Headless
+description: Demo page for the Canada.ca Search UI Contextual
+lang: en
+altLangPage: src-fr.html
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2024-05-29
+stylesheets:
+    - href: "../src/connector.css"
+---
+
+<!--FORM-->
+<form method="GET" action="#wb-land" class="well"> 
+	<div class="row"> 
+		<div class="col-md-8"> 
+			<label for="sch-inp-ac" class="wb-inv">Search keywords:</label>
+		</div> 
+		<div class="col-md-4 text-right"> 
+		<ul class="list-inline">
+			<li><a href="https://www.canada.ca/en/sr/st.html">Search Tips</a></li> 
+			<li><a href="sra-en.html">Advanced Search</a></li>
+		</ul> 
+		</div> 
+	</div>  
+	<div class="input-group mrgn-tp-md"> 
+		<input id="sch-inp-ac" class="form-control" value="" name="q" autocomplete="off" spellcheck="false" type="search" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		<span class="input-group-btn"> <button class="btn btn-primary btn-small" type="submit"> <span class="glyphicon-search glyphicon" aria-hidden="true"></span> <span class="wb-inv">Search</span> </button> </span> 
+	</div> 
+	<p class="mrgn-tp-md "> <a href="srb-en.html">Search all Government of Canada websites</a> </p> 
+	<p id="gc-pi" class="mrgn-tp-md">Don't include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+</form>
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"XYZ",
+	"originLevel3": "/en/employment-social-development/search.html"
+}'></div>
+
+<!--DEMO-EXPECTATIONS-->
+<h2>Expected output for the result section</h2>
+<details>
+	<summary>Output for Results section</summary>
+	[To be completed, see Connector.js for reference until then]
+</details>
+
+<!--SCRIPT-->
+<script type="module" src="../src/connector.js"></script>

--- a/test/src-fr.html
+++ b/test/src-fr.html
@@ -1,0 +1,53 @@
+---
+title: Résultats de la recherche (contextuels à EDSC) pour le gouvernement du Canada avec Headless
+description: Page démo pour l'interface utilisateur de recherche Canada.ca (contextuelle)
+lang: fr
+altLangPage: src-en.html
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2024-05-29
+stylesheets:
+    - href: "../src/connector.css"
+---
+
+<!--FORM-->
+<form method="GET" action="#wb-land" class="well"> 
+	<div class="row"> 
+		<div class="col-md-8"> 
+			<label for="sch-inp-ac" class="wb-inv">Rechercher des mots-clés :</label>
+		</div> 
+		<div class="col-md-4 text-right"> 
+			<ul class="list-inline"> 
+				<li><a href="https://www.canada.ca/fr/sr/tr.html">Trucs de recherche</a></li> 
+				<li><a href="sra-fr.html">Recherche avancée</a></li> 
+			</ul>
+		</div> 
+	</div>  
+	<div class="input-group mrgn-tp-md"> 
+		<input id="sch-inp-ac" class="form-control" value="" name="q" autocomplete="off" spellcheck="false" style="outline: medium none;" type="search" data-fusion-query="safe" aria-describedby="gc-pi"> 
+		<span class="input-group-btn"> <button id="sch-inp" class="btn btn-primary btn-small" name="wb-srch-sub" type="submit"> <span class="glyphicon-search glyphicon"></span> <span class="wb-inv">Rechercher</span> </button> </span> 
+	</div> 
+	<p class="mrgn-tp-md "><a href="srb-fr.html">Effectuer une recherche sur tous les sites Web du gouvernement du Canada</a></p> 
+	<p id="gc-pi" class="mrgn-tp-md">N'incluez pas de renseignements personnels (téléphone, courriel, NAS, renseignements financiers, médicaux ou professionnels).</p>
+</form>
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"XYZ",
+	"originLevel3": "/fr/emploi-developpement-social/rechercher.html"
+}'></div>
+
+<!--DEMO-EXPECTATIONS-->
+<h2>Section Résultats attendu pour la section de résultats</h2>
+<details>
+	<summary>Section Résultats générée</summary>
+	[À compléter, voir Connector.js comme référence pour l'instant]
+</details>
+
+<!--SCRIPT-->
+<script type="module" src="../src/connector.js"></script>

--- a/todo.md
+++ b/todo.md
@@ -1,0 +1,26 @@
+## To do
+
+This list contains outstanding suggestions / non-critical issues identified in previously merged pull requests. The following items do need to be addressed in due time.
+
+- [ ] Potentially come up with an easier way to test locally
+- [ ] Add Expected output on test pages (HTML) and use Jekyll highlights
+- [ ] Finish proper development of Suggestion box (type-ahead)
+- [ ] Remove the need for having a CSS file to be handled by GCWeb instead
+- [ ] Add includes of JS (src) files in a baked in Jekyll variables instead of hardcoded
+- [ ] Align search pages with new GCWeb template and/or define new GCWeb templates
+- [ ] Ensure no section or heading or any element with semantic is added alone/empty on the page 
+- [ ] Improve the form code to not rely on an action that points to an anchor for a dynamically added element, which doesn't exist on the page prior to JS
+- [ ] Create search template specific styles (.page-type-search), to get rid of overusage of .h3 class for example
+- [ ] Leverage wb core features instead of reinving the wheel, such as for language of page and dates. For dates, native JS functions could be leveraged such as: toLocaleDateString
+- [ ] Improve caching of variable that are used multiple times in the script, such as: window.location, then window.location.pathname
+- [ ] Revisit how dates are handled for output formats (need an array of months?)
+- [ ] Make IDs configurable for "suggestion", "result-list", "result-link", "query-summary", "pager"
+- [ ] Add missing pieces such as "error message", "no result" and "did you mean" into our reference implementation as an example
+- [ ] Revisit customEvent to potentially be scoped to the search-ui element instead of document
+- [ ] Document customEvent
+- [ ] Improve warning message when Headless doesn't load
+- [ ] "numberOfPages: 9" and "automaticallyCorrectQuery: false" should be configurable through parameters
+- [ ] Revisit the need to search for postscript and rich text documents (ps and rtf. Are they needed? What's the usecase?
+- [ ] Revisit the "window.location.origin.startsWith( 'file://' )" condition
+- [ ] Investigate Pagination styles when testing from GitHub
+- [ ] Investigate #wb-land focus on Advanced search


### PR DESCRIPTION
This is to bring the project to v1.0.0, which includes:

- Connector script updates related to:
  - Remove query suggestions if www.canada.ca
  - Avoid throwing an error if baseElement can't be found
  - Focus on search actions wasn't consistant (accessibility impact)
- Readme updates related to:
  - Add information related to the project itself, as part of the concept of project/mini-apps for MWS

The following hidden page already has this code for testing purposes: https://www.canada.ca/en/service-canada/francis/srb.html