### PR TITLE
SR-380 - Neutralize all HTML prior display it on the search result page

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -899,7 +899,7 @@ function updateQuerySummaryState( newState ) {
 
 			querySummaryElement.innerHTML = ( ( querySummaryState.query !== "" && !params.isAdvancedSearch ) ? querySummaryTemplateHTML : noQuerySummaryTemplateHTML )
 				.replace( '%[numberOfResults]', numberOfResults )
-				.replace( '%[query]', DOMPurify.sanitize( querySummaryState.query ) )
+				.replace( '%[query]', DOMPurify.sanitize( querySummaryState.query ).replaceAll( "<", "&lt;" ).replaceAll( ">", "&gt;" ) )
 				.replace( '%[queryDurationInSeconds]', querySummaryState.durationInSeconds.toLocaleString( params.lang ) );
 		}
 		else {


### PR DESCRIPTION
@igkislev please ensure this fix or an equivalent fix are included in the next release of the search ui. Ideally that clean up should be completed when parsing the search input or the query string.

cc @Garneauma 