### PR TITLE
SR-454: Improve development env w/ Jekyll & Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,13 @@ nbproject/*
 /.project
 .settings
 .vscode/*
+
+# Jekyll
+_site
+.sass-cache
+.jekyll-cache
+.jekyll-metadata
+vendor
+Gemfile.lock
+
+_data/token.yml

--- a/404.html
+++ b/404.html
@@ -1,0 +1,8 @@
+---
+permalink: /404.html
+title: 404
+---
+
+<div class="container">
+	<p class="lead"><strong>Page not found | <span lang="fr">Page introuvable</span></strong></p>
+</div>

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,27 @@
+source "https://rubygems.org"
+
+# Hello! This is where you manage which Jekyll version is used to run.
+# When you want to use a different version, change it below, save the
+# file and run `bundle install`. Run Jekyll with `bundle exec`, like so:
+#
+#     bundle exec jekyll serve
+#
+# This will help ensure the proper Jekyll version is running.
+# Happy Jekylling!
+gem "jekyll", "~> 4.3.3"
+
+gem 'jekyll-remote-theme'
+
+# Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem
+# and associated library.
+platforms :mingw, :x64_mingw, :mswin, :jruby do
+  gem "tzinfo", ">= 1", "< 3"
+  gem "tzinfo-data"
+end
+
+# Performance-booster for watching directories on Windows
+gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# Lock `http_parser.rb` gem to `v0.6.x` on JRuby builds since newer versions of the gem
+# do not have a Java counterpart.
+gem "http_parser.rb", "~> 0.6.0", :platforms => [:jruby]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -96,5 +96,12 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-htmllint');
 	grunt.loadNpmTasks('grunt-eslint');
 
-	grunt.registerTask('default', ['clean', 'htmllint', 'jshint', 'eslint', 'copy', 'uglify', 'cssmin', 'usebanner']);
+	// Task to fix line endings after minification
+	grunt.registerTask('fixLineEndings', function () {
+		let content = grunt.file.read('dist/connector.min.css');
+		content = content.replace(/\r\n?/g, '\n');
+		grunt.file.write('dist/connector.min.css', content);
+	});
+
+	grunt.registerTask('default', ['clean', 'htmllint', 'jshint', 'eslint', 'copy', 'uglify', 'cssmin', 'usebanner', 'fixLineEndings']);
 };

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Search UI follows [Semantic Versioning 2.0.0](https://semver.org/)
 
 This rubric is for developers.
 
-### Build files
+### Build files for release or to test code quality before opening a Pull request
 
 1. run: npm install -g grunt-cli
 2. run: npm install
@@ -51,19 +51,34 @@ This rubric is for developers.
 
 ### Test as end-user
 
+#### Locally (with Docker)
+
+1. Install Docker
+2. Add an API key to your site settings as described below in [Setting an API key](#setting-an-api-key). Otherwise, please see [Alternative to the API key by getting a token](#alternative-to-the-api-key-by-getting-a-token) below.
+3. run `docker compose up --build`
+
+#### Through GitHub Pages 
+
 1. Push to a branch in your origin remote, in a branch of your choice. It is recommended that you use a dedicated branch for testing, which is different from one where you would be opening a Pull request from.
 2. Make sure your repository has GitHub Pages enabled, on that specific above-mentioned branch.
-3. Since you need a token to communicate with the Coveo API, you can do the following to go to get a token valid for 24 hrs:
-	1. Go to a search page on the Canada.ca preview such as: **/en/sr/srb.html**.
-	2. Open the inspector (developer tool) and look for the `div` tag that has the attribute called `data-gc-search`.
-	3. Inside this attribute, you'll find a Javascript object that has a field called `accessToken`. Grab the value of that token.
-	4. Replace `XYZ` with the token on any page within the /test/ folder of this project, such as **srb-en.html**.
-	5. If you are planning on opening a pull request with your changes, do not forget to put `XYZ` back into the files.
-	6. If the token doesn't seem valid, take another one from the Canada.ca Preview server or you may have passed the 24 hours TTL of the token; get another one.
+
+#### Setting an API key
+
+1. Add a file named `token.yml` inside the `_data` folder. This file needs to simply have a key-value pair of `API_KEY: "[API KEY HERE]"` on line 1. The key value can be found at https://github.com/ServiceCanada/devops-documentation/blob/master/search/local-testing.md to replace the `[API KEY HERE]`. If you do not have access to the previous link, please see the next section on how to use a token as described below.
+
+#### Alternative to the API key by getting a token
+
+Since you need a token to communicate with the Coveo API, you can do the following to go to get a token valid for 24 hrs:
+
+1. Go to a search page on the Canada.ca preview such as: **/en/sr/srb.html**.
+2. Open the inspector (developer tool) and look for the `div` tag that has the attribute called `data-gc-search`.
+3. Inside this attribute, you'll find a Javascript object that has a field called `accessToken`. Grab the value of that token.
+4. Add a file named `token.yml` in the `_data` folder. This file needs to simply have a key-value pair of `API_KEY: "[API KEY HERE]"` on line 1. Add the token value as the key in `[API KEY HERE]`.
+5. If the token doesn't seem valid, take another one from the Canada.ca Preview server or you may have passed the 24 hours TTL of the token; get another one.
 
 ### Deployment
 
-1. Take the content of the "dist" folder and put it on a server. Make sure you have a mechanism in place to handle a key/token
+1. The content of the "dist" folder is what's needed for a release / deployment. See [Build files](#build-files) section above to generate this folder.
 
 ### Configurations, templates and parameters
 
@@ -84,9 +99,7 @@ They must be used within the `[data-gc-search]` attribute. See the **/test/src-e
 - `lang`
 : Langague of the text to output, in short format (`en` or `fr`). Will detect the langauge of the HTML page if not defined. If not determined, default is: `en`
 - `numberOfSuggestions`
-: Number of suggestions to show in the Query suggestion box. Default: `0`
-- `unsupportedSuggestions`
-: Extra mechanism to allow the use of the very early on Query suggestion feature. Default: `false`
+: Number of suggestions to show in the Query Suggestion (QS) box. This will activate the QS feature on your search page. Default: `0`
 - `enableHistoryPush`
 : Allows for UI elements that are not hyperlink tags to register their action in the history, such as pagination. Default: `true`
 - `isContextSearch`
@@ -187,7 +200,7 @@ Sometimes your search pages contain more than one input relevant to the search's
 - `noneq`
 : Search for anything but the search terms in input
 - `fqocct`
-: Search for all of the search terms in input
+: Search for all of the search terms in input, matching on title or URL only
 - `fqupdate`
 : Search for search terms in input, on pages that have been modified only since a certain amount of time. Options are: `datemodified_dt:[now-1day to now]`, `datemodified_dt:[now-7days to now]`, `datemodified_dt:[now-1month to now]`, `datemodified_dt:[now-1year to now]`
 - `dmn`
@@ -197,8 +210,16 @@ Sometimes your search pages contain more than one input relevant to the search's
 - `elctn_cat`
 : Used specifically for Elections Canada, to define a scope of search amongst their collection. See **/src/connector.js** to see all the options available
 - `site`
-: Used specifically for Elections Canada, to search within a specific site
+: Used specifically for Canada Gazette, to search within a specific site
+- `year`
+: Used specifically for budget limit search results to be created or modified on a given year, with minimum being 2000 and max being current year +1
 - `filetype`
 : Search , within documents of a certain file type. Options are: `application/pdf`, `ps`, `application/msword`, `application/vnd.ms-excel`, `application/vnd.ms-powerpoint`, `application/rtf`
 - `originLevel3`
 : Allows for mimicking a specific search page/context by setting its path through this URL parameter
+
+### Other
+
+#### Analytics tracking
+
+Custom event named `searchEvent` can used to hook onto from Analytics tools, such as Adobe Analytics. This allows to listen to search actions, more specifically "doing a search", since the Search UI is acting similar to a Single Page App (SPA).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,14 @@
 
 # Security
 
-**Do not post any security issues on the public repository!** Security vulnerabilities must be reported via a contact method listed on Principal Publisher's GCpedia page: https://www.gcpedia.gc.ca/wiki/Principal_Publisher_at_Service_Canada.
+**Do not post any security issues on the public repository!** Example of a security issue would be to expose the restricted API key provided through the instructions on the README. 
+
+Security vulnerabilities must be reported via a contact method listed on Principal Publisher's GCxchange site: https://gcxgce.sharepoint.com/teams/10001402/SitePages/Search.aspx.
 
 ______________________
 
 ## Sécurité
 
-**Ne publiez aucun problème de sécurité sur le dépôt publique!** Les vulnérabilités de sécurité doivent être signalées via une méthode de contact proposée sur la page GCpédia de l'Éditeur principal : https://www.gcpedia.gc.ca/wiki/%C3%89diteur_principal_de_Service_Canada.
+**Ne publiez aucun problème de sécurité sur le dépôt publique!** Un exemple de problème de sécurité serait d'exposer la clé API limitée fournie à travers les instructions du README.
+
+Les vulnérabilités de sécurité doivent être signalées via une méthode de contact proposée sur le site GCéchange de l'Éditeur principal : https://gcxgce.sharepoint.com/teams/10001402/SitePages/fr/Home.aspx.

--- a/_config.yml
+++ b/_config.yml
@@ -1,10 +1,35 @@
+plugins:
+  - jekyll-remote-theme
+
 remote_theme: wet-boew/gcweb-jekyll
+
 title: Search UI for Canada.ca Search
 
-#
-# Page front matter defaults
 defaults:
   - scope:
       path: "" # Ensure it's applied to all pages
     values:
       layout: default
+
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - docker-compose.yml
+  - Gruntfile.js
+  - dist/
+  - package.json
+  - package-lock.json
+  - LICENSE
+  - CONDE_OF_CONDUCT.md
+  - CONTRIBUTING.md
+  - SECURITY.md
+  - README.md
+  - todo.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  jekyll:
+    image: bretfisher/jekyll-serve
+    container_name: search-ui-site
+    volumes:
+      - .:/site
+    ports:
+      - '4000:4000'

--- a/index.html
+++ b/index.html
@@ -1,16 +1,32 @@
 ---
 title: Search user interface (UI) with Headless
+lang: en
+dateModified: 2025-02-24
 ---
 
-<p class="lead">This is a demo site for the Search UI.</p>
+<p class="lead">This is a demo site for the GC Search UI.</p>
 
-<h2 id="test">Testing</h2>
+<h2 id="test">Test pages</h2>
 
+<h3>Regular pages</h3>
 <ul>
-	<li><a href="test/srb-en.html">Sample basic search page</a></li>
-	<li><a href="test/sra-en.html">Sample advanced search page</a></li>
-	<li><a href="test/src-en.html">Sample contextual search page</a></li>
-	<li><a href="test/srb-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (base)</a></li>
-	<li><a href="test/sra-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (avancée)</a></li>
-	<li><a href="test/src-fr.html" hreflang="fr" lang="fr">Exemple de page de résultats de la recherche (contextuelle)</a></li>
+	<li><a href="test/srb-en.html">Basic search page</a></li>
+	<li><a href="test/sra-en.html">Advanced search page</a></li>
+	<li><a href="test/src-en.html">Contextual search page</a></li>
+	<li><a href="test/qs-en.html">Search page with Query Suggestions (type-ahead)</a></li>
+	<li><a href="test/srb-fr.html" hreflang="fr" lang="fr">Page de recherche (base)</a></li>
+	<li><a href="test/sra-fr.html" hreflang="fr" lang="fr">Page de recherche (avancée)</a></li>
+	<li><a href="test/src-fr.html" hreflang="fr" lang="fr">Page de recherche (contextuelle)</a></li>
+	<li><a href="test/qs-fr.html" hreflang="fr" lang="fr">Page de recherche avec Suggestions de termes</a></li>
 </ul>
+
+<h3>Advanced tests</h3>
+<ul>
+	<li><a href="test/election.html">Elections Canada sample</a></li>
+	<li><a href="test/budget.html">Budget sample</a></li>
+	<li><a href="test/gazette.html">Canada Gazette sample</a></li>
+	<li><a href="test/template.html">Custom summary and results templates</a></li>
+</ul>
+
+<hr>
+<p>Please <a href="https://github.com/ServiceCanada/search-ui">refer to the README documentation</a> to get more information on the GC Search UI.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,25 +4,19 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@aashutoshrathi/word-wrap": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-			"dev": true
-		},
 		"@eslint-community/eslint-utils": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+			"integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
 			"dev": true,
 			"requires": {
-				"eslint-visitor-keys": "^3.3.0"
+				"eslint-visitor-keys": "^3.4.3"
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.10.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-			"integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+			"version": "4.12.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
@@ -75,18 +69,18 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.0.tgz",
-			"integrity": "sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+			"integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
 			"dev": true
 		},
 		"@humanwhocodes/config-array": {
-			"version": "0.11.14",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
-			"integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+			"version": "0.13.0",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+			"integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
 			"dev": true,
 			"requires": {
-				"@humanwhocodes/object-schema": "^2.0.2",
+				"@humanwhocodes/object-schema": "^2.0.3",
 				"debug": "^4.3.1",
 				"minimatch": "^3.0.5"
 			},
@@ -109,9 +103,9 @@
 			"dev": true
 		},
 		"@humanwhocodes/object-schema": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
-			"integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+			"integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
 			"dev": true
 		},
 		"@nodelib/fs.scandir": {
@@ -141,9 +135,9 @@
 			}
 		},
 		"@ungap/structured-clone": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true
 		},
 		"abbrev": {
@@ -153,9 +147,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "8.11.3",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
-			"integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+			"version": "8.14.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+			"integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
 			"dev": true
 		},
 		"acorn-jsx": {
@@ -380,9 +374,9 @@
 			"dev": true
 		},
 		"cross-spawn": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+			"version": "7.0.6",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
 			"dev": true,
 			"requires": {
 				"path-key": "^3.1.0",
@@ -414,12 +408,12 @@
 			"dev": true
 		},
 		"debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
 			"dev": true,
 			"requires": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			}
 		},
 		"deep-is": {
@@ -468,18 +462,18 @@
 			"dev": true
 		},
 		"domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+			"integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
 			"dev": true,
 			"requires": {
 				"domelementtype": "1"
 			}
 		},
 		"domutils": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-			"integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+			"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
 			"dev": true,
 			"requires": {
 				"dom-serializer": "0",
@@ -493,9 +487,9 @@
 			"dev": true
 		},
 		"entities": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-			"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+			"integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
 			"dev": true
 		},
 		"escape-string-regexp": {
@@ -505,16 +499,16 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "8.57.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.0.tgz",
-			"integrity": "sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==",
+			"version": "8.57.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
 				"@eslint/eslintrc": "^2.1.4",
-				"@eslint/js": "8.57.0",
-				"@humanwhocodes/config-array": "^0.11.14",
+				"@eslint/js": "8.57.1",
+				"@humanwhocodes/config-array": "^0.13.0",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
 				"@ungap/structured-clone": "^1.2.0",
@@ -659,9 +653,9 @@
 			"dev": true
 		},
 		"esquery": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
 			"dev": true,
 			"requires": {
 				"estraverse": "^5.1.0"
@@ -719,9 +713,9 @@
 			"dev": true
 		},
 		"fastq": {
-			"version": "1.17.1",
-			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
-			"integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
+			"version": "1.19.0",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
+			"integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
@@ -845,9 +839,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
-			"integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+			"integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
 			"dev": true
 		},
 		"fs.realpath": {
@@ -959,9 +953,9 @@
 			},
 			"dependencies": {
 				"async": {
-					"version": "3.2.5",
-					"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-					"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
+					"version": "3.2.6",
+					"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+					"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
 					"dev": true
 				},
 				"glob": {
@@ -1291,26 +1285,65 @@
 				"promise": "^8.0.2"
 			},
 			"dependencies": {
+				"entities": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+					"integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+					"dev": true
+				},
+				"htmlparser2": {
+					"version": "3.10.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+					"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+					"dev": true,
+					"requires": {
+						"domelementtype": "^1.3.1",
+						"domhandler": "^2.3.0",
+						"domutils": "^1.5.1",
+						"entities": "^1.1.1",
+						"inherits": "^2.0.1",
+						"readable-stream": "^3.1.1"
+					}
+				},
 				"lodash": {
 					"version": "4.17.21",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 					"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 					"dev": true
+				},
+				"readable-stream": {
+					"version": "3.6.2",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+					"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"string_decoder": {
+					"version": "1.3.0",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+					"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+					"dev": true,
+					"requires": {
+						"safe-buffer": "~5.2.0"
+					}
 				}
 			}
 		},
 		"htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+			"version": "3.8.3",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+			"integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
 			"dev": true,
 			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
+				"domelementtype": "1",
+				"domhandler": "2.3",
+				"domutils": "1.5",
+				"entities": "1.0",
+				"readable-stream": "1.1"
 			}
 		},
 		"iconv-lite": {
@@ -1320,15 +1353,15 @@
 			"dev": true
 		},
 		"ignore": {
-			"version": "5.3.1",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-			"integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true
 		},
 		"import-fresh": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+			"integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
 			"dev": true,
 			"requires": {
 				"parent-module": "^1.0.0",
@@ -1415,44 +1448,6 @@
 				"strip-json-comments": "1.0.x"
 			},
 			"dependencies": {
-				"domhandler": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-					"integrity": "sha512-q9bUwjfp7Eif8jWxxxPSykdRZAb6GkguBGSgvvCrhI9wB71W2K/Kvv4E61CF/mcCfnVJDeDWx/Vb/uAqbDj6UQ==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "1"
-					}
-				},
-				"domutils": {
-					"version": "1.5.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-					"integrity": "sha512-gSu5Oi/I+3wDENBsOWBiRK1eoGxcywYSqg3rR960/+EfY0CF4EX1VPkgHOZ3WiS/Jg2DtliF6BhWcHlfpYUcGw==",
-					"dev": true,
-					"requires": {
-						"dom-serializer": "0",
-						"domelementtype": "1"
-					}
-				},
-				"entities": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-					"integrity": "sha512-LbLqfXgJMmy81t+7c14mnulFHJ170cM6E+0vMXR9k/ZiZwgX8i5pNgjTCX3SO4VeUsFLV+8InixoretwU+MjBQ==",
-					"dev": true
-				},
-				"htmlparser2": {
-					"version": "3.8.3",
-					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-					"integrity": "sha512-hBxEg3CYXe+rPIua8ETe7tmG3XDn9B0edOE/e9wH2nLczxzgdu0m0aNHY+5wFZiviLWLdANPJTssa92dMcXQ5Q==",
-					"dev": true,
-					"requires": {
-						"domelementtype": "1",
-						"domhandler": "2.3",
-						"domutils": "1.5",
-						"entities": "1.0",
-						"readable-stream": "1.1"
-					}
-				},
 				"lodash": {
 					"version": "4.17.21",
 					"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -1467,24 +1462,6 @@
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
-				},
-				"readable-stream": {
-					"version": "1.1.14",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-					"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
-					"dev": true,
-					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
-						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
-					}
-				},
-				"string_decoder": {
-					"version": "0.10.31",
-					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-					"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-					"dev": true
 				}
 			}
 		},
@@ -1605,9 +1582,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -1635,17 +1612,17 @@
 			}
 		},
 		"optionator": {
-			"version": "0.9.3",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+			"integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
 			"dev": true,
 			"requires": {
-				"@aashutoshrathi/word-wrap": "^1.2.3",
 				"deep-is": "^0.1.3",
 				"fast-levenshtein": "^2.0.6",
 				"levn": "^0.4.1",
 				"prelude-ls": "^1.2.1",
-				"type-check": "^0.4.0"
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.5"
 			}
 		},
 		"p-limit": {
@@ -1733,14 +1710,15 @@
 			"dev": true
 		},
 		"readable-stream": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+			"integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.1",
+				"isarray": "0.0.1",
+				"string_decoder": "~0.10.x"
 			}
 		},
 		"resolve-from": {
@@ -1804,13 +1782,10 @@
 			"dev": true
 		},
 		"string_decoder": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.2.0"
-			}
+			"version": "0.10.31",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+			"integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+			"dev": true
 		},
 		"strip-ansi": {
 			"version": "3.0.1",
@@ -1855,9 +1830,9 @@
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.17.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-			"integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+			"version": "3.19.3",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+			"integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
 			"dev": true
 		},
 		"underscore": {
@@ -1897,6 +1872,12 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
 			"integrity": "sha512-E87fdQ/eRJr9W1X4wTPejNy9zTW3FI2vpCZSJ/HAY+TkjKVC0TUm1jk6vn2Z7qay0DQy0+RBGdXxj+RmmiGZKQ==",
+			"dev": true
+		},
+		"word-wrap": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+			"integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
 			"dev": true
 		},
 		"wrappy": {

--- a/test/budget.html
+++ b/test/budget.html
@@ -1,0 +1,56 @@
+---
+title: Sample advanced search for Budget (custom)
+description: Demo page for the Canada.ca Search UI Advanced for Budget
+lang: en
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2025-02-24
+css: "../src/connector.css"
+script:
+- src: "../src/connector.js"
+  type: module
+---
+
+<!-- Sorting example -->
+<div class="alert alert-info">
+	<p><strong>Try this out!</strong> Click on the following link to search for "Taxes" with the search results ordered by dates descending, instead of relevance.</p>
+	<p><a href="budget.html?allq=Taxes&sort=date">Sort results by date</a></p>
+	<p>Note: Current implementation of the sorting feature requires server-side code or additional custom JS to make dynamic with the search query.</p>
+</div>
+
+<!--FORM-->
+<form id="gc-searchbox">  
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Find pages with...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon1">all these words:</label> 
+			<input name="allq" class="form-control" id="advseacon1" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<p id="gc-pi" class="mrgn-tp-md">Don’t include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+	</fieldset> 
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Then narrow your results by...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon5_y">year:</label> 
+			<select class="form-control" name="year" id="advseacon5_y" data-fusion-query="safe"> 
+			<option selected value="">select year</option> 
+			<option value="2024">2024</option> 
+			<option value="2023">2023</option> 
+			<option value="2022">2022</option> 
+			<option value="2021">2021</option> </select> 
+		</div>
+	</fieldset> 
+	<button type="submit" class="btn btn-md btn-primary">Search</button> 
+</form> 
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"isAdvancedSearch": true,
+	"originLevel3": "/en/department-finance/search-budget/advanced-search.html"
+}'></div>

--- a/test/demoted/v1_1_0_srb-en.html
+++ b/test/demoted/v1_1_0_srb-en.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../../src/connector.css"
-script: "../../src/connector.js"
+script:
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -29,7 +31,7 @@ script: "../../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"originLevel3": "/en/sr/srb.html"
 }'></div>
 <p class="text-center small"><a href="sra-en.html">Perform an advanced search</a></p>

--- a/test/demoted/v1_1_0_srb-fr.html
+++ b/test/demoted/v1_1_0_srb-fr.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../../src/connector.css"
-script: "../../src/connector.js"
+script:
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -29,7 +31,7 @@ script: "../../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"originLevel3": "/fr/sr/srb.html"
 }'></div>
 <p class="text-center small"><a href="sra-fr.html">Effectuer une recherche avancée</a></p>

--- a/test/demoted/v1_1_0_src-en.html
+++ b/test/demoted/v1_1_0_src-en.html
@@ -9,10 +9,10 @@ pageType: recherche
 share: false
 deptfeature: false
 dateModified: 2024-06-05
-css:
-	- "../../src/connector.css"
+css: "../../src/connector.css"
 script:
-	- "../../src/connector.js"
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -40,7 +40,7 @@ script:
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"originLevel3": "/en/employment-social-development/search.html"
 }'></div>
 

--- a/test/demoted/v1_1_0_src-fr.html
+++ b/test/demoted/v1_1_0_src-fr.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../../src/connector.css"
-script: "../../src/connector.js"
+script:
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -38,7 +40,7 @@ script: "../../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"originLevel3": "/fr/emploi-developpement-social/rechercher.html"
 }'></div>
 

--- a/test/election.html
+++ b/test/election.html
@@ -1,0 +1,51 @@
+---
+title: Sample advanced search for Elections (custom)
+description: Demo page for the Canada.ca Search UI Advanced for Elections
+lang: en
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2025-02-24
+css: "../src/connector.css"
+script:
+- src: "../src/connector.js"
+  type: module
+---
+
+<!--FORM-->
+<form id="gc-searchbox">  
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Find pages with...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon1">all these words:</label> 
+			<input name="allq" class="form-control" id="advseacon1" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<p id="gc-pi" class="mrgn-tp-md">Don’t include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+	</fieldset> 
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Then narrow your results by...</legend> 
+		<div class="form-group"> 
+			<label for="elctn_cat">collection:</label> 
+			<select class="form-control" id="elctn_cat" name="elctn_cat" data-fusion-query="safe">
+				<option value="">Full Site</option>
+				<option value="press_release">Press releases</option>
+				<option value="research">Research documents</option>
+				<option value="officer_manuals">Election Officer's Manuals</option>
+				<option value="ogi">Opinions, Guidelines and Interpretations</option>
+				<option value="comp">Compendium of Election Administration in Canada</option>
+				<option value="his">A History of the vote in Canada</option>
+			</select>
+		</div> 
+	</fieldset> 
+	<button type="submit" class="btn btn-md btn-primary">Search</button> 
+</form> 
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"originLevel3": "/en/elections-canada/search/advanced-search.html"
+}'></div>

--- a/test/gazette.html
+++ b/test/gazette.html
@@ -1,0 +1,47 @@
+---
+title: Sample advanced search for Gazette (custom)
+description: Demo page for the Canada.ca Search UI Advanced for Gazette
+lang: en
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2025-02-24
+css: "../src/connector.css"
+script:
+- src: "../src/connector.js"
+  type: module
+---
+
+<!--FORM-->
+<form id="gc-searchbox">  
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Find pages with...</legend> 
+		<div class="form-group"> 
+			<label for="advseacon1">all these words:</label> 
+			<input name="allq" class="form-control" id="advseacon1" maxlength="100" data-fusion-query="safe" aria-describedby="gc-pi">
+		</div> 
+		<p id="gc-pi" class="mrgn-tp-md">Don’t include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+	</fieldset> 
+	<fieldset> 
+		<legend class="h3 mrgn-tp-sm">Then narrow your results by...</legend> 
+		<div class="form-group mrgn-bttm-md">
+			<label for="advseacon5_y">file format:</label>
+			<select class="form-control" name="filetype" id="filetype" data-fusion-query="safe">
+			<option value="">any format</option>
+			<option value="application/pdf">Portable Document Format (.pdf)</option>
+			<option value="text/html">HTML (.html)</option>
+			</select>
+		</div>
+	</fieldset> 
+	<button type="submit" class="btn btn-md btn-primary">Search</button> 
+</form> 
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"originLevel3": "/en/public-services-procurement/gazette/advanced-search.html"
+}'></div>

--- a/test/qs-en.html
+++ b/test/qs-en.html
@@ -1,14 +1,14 @@
 ---
-title: Basic search page for Governement of Canada using Headless
-description: Demo page for the Canada.ca Search UI Basic
+title: Search page with Query Suggestions (QS)
+description: Demo page for the QS feature in the Canada.ca Search UI Basic
 lang: en
-altLangPage: srb-fr.html
+altLangPage: qs-fr.html
 nositesearch: true
 pageclass: page-type-search
 pageType: recherche
 share: false
 deptfeature: false
-dateModified: 2024-06-05
+dateModified: 2025-02-19
 css: "../src/connector.css"
 script:
 - src: "../src/connector.js"
@@ -32,7 +32,8 @@ script:
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
 	"accessToken":"{{ site.data.token.API_KEY }}",
-	"originLevel3": "/en/sr/srb.html"
+	"originLevel3": "/en/sr/srb.html",
+	"numberOfSuggestions": 5
 }'></div>
 <p class="text-center small"><a href="sra-en.html">Perform an advanced search</a></p>
 

--- a/test/qs-fr.html
+++ b/test/qs-fr.html
@@ -1,14 +1,14 @@
 ---
-title: Résultats de la recherche (base) pour le gouvernement du Canada avec Headless
-description: Page démo pour l'interface utilisateur de recherche Canada.ca (base)
+title: Résultats de la recherche avec Suggestions de termes
+description: Page démo pour la fonctionnalité Suggestions de termes dans l'interface utilisateur de recherche Canada.ca
 lang: fr
-altLangPage: srb-en.html
+altLangPage: qs-en.html
 nositesearch: true
 pageclass: page-type-search
 pageType: recherche
 share: false
 deptfeature: false
-dateModified: 2024-06-05
+dateModified: 2025-02-19
 css: "../src/connector.css"
 script:
 - src: "../src/connector.js"
@@ -32,7 +32,8 @@ script:
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
 	"accessToken":"{{ site.data.token.API_KEY }}",
-	"originLevel3": "/fr/sr/srb.html"
+	"originLevel3": "/fr/sr/srb.html",
+	"numberOfSuggestions": 5
 }'></div>
 <p class="text-center small"><a href="sra-fr.html">Effectuer une recherche avancée</a></p>
 

--- a/test/sra-en.html
+++ b/test/sra-en.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
-script: "../src/connector.js"
+script:
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -65,8 +67,9 @@ script: "../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"isAdvancedSearch": true,
+	"enableHistoryPush": false,
 	"originLevel3": "/en/sr/srb/sra.html"
 }'></div>
 

--- a/test/sra-fr.html
+++ b/test/sra-fr.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
-script: "../src/connector.js"
+script:
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -65,8 +67,9 @@ script: "../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
+	"accessToken":"{{ site.data.token.API_KEY }}",
 	"isAdvancedSearch": true,
+	"enableHistoryPush": false,
 	"originLevel3": "/fr/sr/srb/sra.html"
 }'></div>
 

--- a/test/src-en.html
+++ b/test/src-en.html
@@ -9,10 +9,10 @@ pageType: recherche
 share: false
 deptfeature: false
 dateModified: 2024-06-05
-css:
-	- "../src/connector.css"
+css: "../src/connector.css"
 script:
-	- "../src/connector.js"
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -40,8 +40,9 @@ script:
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
-	"originLevel3": "/en/employment-social-development/search.html"
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"originLevel3": "/en/employment-social-development/search.html",
+	"isContextSearch": true
 }'></div>
 
 <!--DEMO-EXPECTATIONS-->

--- a/test/src-fr.html
+++ b/test/src-fr.html
@@ -10,7 +10,9 @@ share: false
 deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
-script: "../src/connector.js"
+script: 
+- src: "../src/connector.js"
+  type: module
 ---
 
 <!--FORM-->
@@ -38,8 +40,9 @@ script: "../src/connector.js"
 <div data-gc-search='{
 	"searchHub": "canada-gouv-public-websites",
 	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
-	"accessToken":"XYZ",
-	"originLevel3": "/fr/emploi-developpement-social/rechercher.html"
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"originLevel3": "/fr/emploi-developpement-social/rechercher.html",
+	"isContextSearch": true
 }'></div>
 
 <!--DEMO-EXPECTATIONS-->

--- a/test/template.html
+++ b/test/template.html
@@ -1,0 +1,62 @@
+---
+title: Search page with custom templates for summary and results
+description: Demo page for custom summary and results templates in the Canada.ca Search UI
+lang: en
+nositesearch: true
+pageclass: page-type-search
+pageType: recherche
+share: false
+deptfeature: false
+dateModified: 2025-02-19
+css: "../src/connector.css"
+script:
+- src: "../src/connector.js"
+  type: module
+---
+
+<!--FORM-->
+<form id="gc-searchbox" class="mrgn-tp-sm">
+	<div class="input-group mrgn-tp-lg">
+		<label class="wb-inv" for="othersrch">Search Government of Canada websites</label>
+		<input id="othersrch" class="form-control" value="" name="q" autocomplete="off" spellcheck="false" type="search" aria-describedby="gc-pi">
+		<span class="input-group-btn">
+		<button class="btn btn-primary btn-small" type="submit"> <span class="glyphicon-search glyphicon" aria-hidden="true"></span> <span class="wb-inv">Search</span> </button>
+		</span>
+	</div>
+	<p id="gc-pi" class="mrgn-tp-md">Don’t include personal information (telephone, email, SIN, financial, medical, or work details).</p>
+</form>
+
+<!--RESULTS-->
+<div data-gc-search='{
+	"searchHub": "canada-gouv-public-websites",
+	"organizationId": "employmentandsocialdevelopmentcanadanonproduction14o5d9wry",
+	"accessToken":"{{ site.data.token.API_KEY }}",
+	"originLevel3": "/en/sr/srb.html",
+	"lang": "en",
+	"searchBoxQuery": "#othersrch",
+	"enableHistoryPush": false
+}'></div>
+<p class="text-center small"><a href="sra-en.html">Perform an advanced search</a></p>
+
+<!--TEMPLATES-->
+<template id="sr-query-summary">
+    <div class="bg-gctheme text-white py-3 px-3 mt-1 mb-4"><h2 class="my-0">%[numberOfResults] results for "%[query]". Search took %[queryDurationInSeconds] seconds.</h2></div>
+    </p>
+</template>
+<template id="sr-single">
+    <div class="panel brdr-tp brdr-rght brdr-bttm brdr-lft mb-0">
+        <div class="panel-body">
+            <div class="mrgn-tp-sm mrgn-bttm-sm mrgn-rght-sm mrgn-lft-sm">
+                <h3 class="mrgn-tp-0"><a id="%[itemId]" class="result-link" href="https://www.canada.ca">%[result.title]</a></h3> 
+                <p><time datetime="%[short-date-en]" class="text-muted">%[long-date-en]</time> &ndash; %[highlightedExcerpt]</p>
+            </div>
+        </div>
+    </div>
+</template>
+
+<!--DEMO-EXPECTATIONS-->
+<h2>Expected output for the result section</h2>
+<details>
+	<summary>Output for Results section</summary>
+	[To be completed, see Connector.js for reference until then]
+</details>

--- a/todo.md
+++ b/todo.md
@@ -2,12 +2,18 @@
 
 This list contains outstanding suggestions / non-critical issues identified in previously merged pull requests. The following items do need to be addressed in due time.
 
+- [x] Potentially come up with an easier way to test locally
+- [x] Add includes of JS (src) files in a baked in Jekyll variables instead of hardcoded
+- [x] Revisit the need to search for postscript and rich text documents (ps and rtf. Are they needed? What's the usecase?
+- [x] Revisit the "window.location.origin.startsWith( 'file://' )" condition
+- [x] Investigate Pagination styles when testing from GitHub
+- [x] Investigate #wb-land focus on Advanced search
+- [x] Document customEvent
+- [x] Finish proper development of Query Suggestion (QS), outside of GCWeb
+- [ ] Move QS generic integration to GCWeb
 - [ ] Remove the need for having a CSS file to be handled by GCWeb instead!
 - [ ] Add missing pieces such as "error message", "no result" and "did you mean" into our reference implementation as an example
-- [ ] Potentially come up with an easier way to test locally
 - [ ] Add Expected output on test pages (HTML) and use Jekyll highlights
-- [ ] Finish proper development of Suggestion box (type-ahead)
-- [x] Add includes of JS (src) files in a baked in Jekyll variables instead of hardcoded
 - [ ] Align search pages with new GCWeb template and/or define new GCWeb templates
 - [ ] Ensure no section or heading or any element with semantic is added alone/empty on the page 
 - [ ] Improve the form code to not rely on an action that points to an anchor for a dynamically added element, which doesn't exist on the page prior to JS
@@ -17,10 +23,5 @@ This list contains outstanding suggestions / non-critical issues identified in p
 - [ ] Revisit how dates are handled for output formats (need an array of months?)
 - [ ] Make IDs configurable for "suggestion", "result-list", "result-link", "query-summary", "pager"
 - [ ] Revisit customEvent to potentially be scoped to the search-ui element instead of document
-- [ ] Document customEvent
 - [ ] Improve warning message when Headless doesn't load
 - [ ] "numberOfPages: 9" and "automaticallyCorrectQuery: false" should be configurable through parameters
-- [ ] Revisit the need to search for postscript and rich text documents (ps and rtf. Are they needed? What's the usecase?
-- [ ] Revisit the "window.location.origin.startsWith( 'file://' )" condition
-- [x] Investigate Pagination styles when testing from GitHub
-- [x] Investigate #wb-land focus on Advanced search


### PR DESCRIPTION
Everything is this PR is related to the local development setup, and has **no impact on the distribution files**. Its purpose is to improve the repository to facilitate contribution and testing. As part of this PR, you'll see that:

- You can now run a test website locally with Docker.
  - It uses an existing image which comes in handy for running Jekyll on a local server [bretfisher/jekyll-serve](https://github.com/BretFisher/jekyll-serve).
- The docker website leverages the remote [GCWeb Jekyll theme](https://github.com/wet-boew/gcweb-jekyll).
  - Uses a newly added front-matter option for scripts of type module. 
- The website hosted on local server updates itself upon changes to the HTML, CSS and JS files.
- Search pages work as expected thanks to a new approach with adding an API key as a Jekyll site-wide data variable.
- It still allows you to build distribution files with linting and other code quality checks with Grunt.
- It still allows you to spin up GitHub pages on your fork (please do not expose the API key, use the token alternative instead).
- Improved documentation to guide developement work.
- Expansion of test pages to include more use cases such as overriding templates for custom ones, as per the maintenance plan forward.
  - I use `test/qs-en.html` and `test/qs-fr.html` to test PR #28.
- Enforces the line ending for CSS build to be linux line ending in the distribution file, as per the maintenance plan forward.

Consequently, this PR has the following relation to other PRs:

- Is dependent on [GCWeb's PR 2474](https://github.com/wet-boew/GCWeb/pull/2474) to be merged prior to merging this one.
- Is related to PR 10 in Service Canada's internal documentation website (not dependent).
- Is a prerequisite to merging the PR #28 for Query Suggestions and other changes.
