### PR TITLE
Misc: Add token page to test search pages in session

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Search UI follows [Semantic Versioning 2.0.0](https://semver.org/)
 
 ## Getting started
 
-This rubric is for developers.
+This rubric is for developers and testers.
 
 ### Build files for release or to test code quality before opening a Pull request
 
@@ -72,6 +72,14 @@ Since you need a token to communicate with the Coveo API, you can do the followi
 5. If the token doesn't seem valid or if you have passed the 24 hours time-to-live (TTL), go back to step one and take another one from the Canada.ca Preview server.
 
 #### Testing through GitHub Pages 
+
+##### Main website
+
+At all time, you can visit the GitHub website to see the GC Search UI with the latest Pull requests merged at play: https://servicecanada.github.io/search-ui/
+
+##### In your fork
+
+This is to test your changes usually before opening a Pull request.
 
 1. Add the required token on HTML pages would like to test by [following the instructions on Alternative to the API key by getting a token](#alternative-to-the-api-key-by-getting-a-token). Do not use the `token.yml` approach documented for testing locally, since it may generate potential a [security risk](SECURITY.md) in the context of GitHub pages.
 2. Push your code to a branch of your choice in your origin remote (fork). It is recommended that you use a dedicated branch for testing, one that you would never open a Pull request from.

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@ dateModified: 2025-02-24
 <p class="lead">This is a demo site for the GC Search UI.</p>
 
 <h2 id="test">Test pages</h2>
+<p>To test search pages, please make sure you <a href="test/index.html">have a valid token</a>.</p>
 
 <h3>Regular pages</h3>
 <ul>

--- a/test/assets/token.js
+++ b/test/assets/token.js
@@ -1,0 +1,32 @@
+// This file is to facilitate testing of the search pages through GitHub pages
+
+const formToken = document.getElementById( "sr-token" );
+const searchElm = document.querySelector( "[data-gc-search]" );
+const sessionName = "searchToken";
+const tokenSaved = sessionStorage.getItem( sessionName );
+
+if( searchElm && tokenSaved ) {
+	let configData = JSON.parse( searchElm.dataset.gcSearch );
+
+	configData.accessToken = tokenSaved;
+	searchElm.dataset.gcSearch = JSON.stringify( configData );
+}
+
+if( formToken ) {
+	formToken.onsubmit = function( e ) {
+		e.preventDefault();
+
+		let formData = new FormData( formToken );
+		let statusElm = document.getElementById( "sr-token-ok" );
+		let tmpElm = document.createElement( "DIV" );
+
+		tmpElm.innerHTML = formData.get( "token" );
+		formData = tmpElm.textContent;
+		sessionStorage.setItem( sessionName, formData );
+
+		statusElm.hidden = false;
+		const hideFeedback = setTimeout( function() { statusElm.hidden = true; }, 5000 );
+
+		return false;
+	};
+}

--- a/test/budget.html
+++ b/test/budget.html
@@ -10,6 +10,7 @@ deptfeature: false
 dateModified: 2025-02-24
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/election.html
+++ b/test/election.html
@@ -10,6 +10,7 @@ deptfeature: false
 dateModified: 2025-02-24
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/gazette.html
+++ b/test/gazette.html
@@ -10,6 +10,7 @@ deptfeature: false
 dateModified: 2025-02-24
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,24 @@
+---
+title: Add token to test search pages
+description: This page allows to add a token to test search pages for the duration of a session
+lang: en
+dateModified: 2025-05-15
+breadcrumbs:
+- title: "GC Search UI"
+  link: "../index.html"
+script: assets/token.js
+---
+
+<div class="alert alert-warning">
+	<p>Use the form below to facilitate testing search pages by saving a token for the <strong>duration of your session</strong>. Please refer to the <a href="https://github.com/ServiceCanada/search-ui?tab=readme-ov-file#setting-an-api-key">Readme file to get a valid access token or API key</a>.</p>
+</div>
+
+<form action="index.html" id="sr-token" class="form-inline">   
+	<div class="form-group"> 
+		<label for="sr-token-input" class="wb-inv">Token:</label> 
+		<input name="token" id="sr-token-input" class="form-control" placeholder="Token" pattern="(\w|\.|-){30,}" maxlength="600" autocomplete="off" required>
+	</div> 
+	<button type="submit" class="btn btn-primary">Save token</button>
+
+	<p id="sr-token-ok" class="mrgn-tp-md mrgn-bttm-lg" role="status" hidden><span class="glyphicon glyphicon-ok text-success mrgn-rght-sm" aria-hidden="true"></span> Token saved!</p>
+</form> 

--- a/test/qs-en.html
+++ b/test/qs-en.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2025-02-19
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/qs-fr.html
+++ b/test/qs-fr.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2025-02-19
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/sra-en.html
+++ b/test/sra-en.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/sra-fr.html
+++ b/test/sra-fr.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/srb-en.html
+++ b/test/srb-en.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/srb-fr.html
+++ b/test/srb-fr.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/src-en.html
+++ b/test/src-en.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/src-fr.html
+++ b/test/src-fr.html
@@ -11,6 +11,7 @@ deptfeature: false
 dateModified: 2024-06-05
 css: "../src/connector.css"
 script: 
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---

--- a/test/template.html
+++ b/test/template.html
@@ -10,6 +10,7 @@ deptfeature: false
 dateModified: 2025-02-19
 css: "../src/connector.css"
 script:
+- src: "assets/token.js"
 - src: "../src/connector.js"
   type: module
 ---


### PR DESCRIPTION
This change does not affect the distribution file; this is just to improve the GitHub pages site.

From the moment this PR is merged, the website located here will have working test pages (when getting a valid token) https://servicecanada.github.io/search-ui/