### PR TITLE
Bugfix: Repeated breadcrumb issue

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -1207,7 +1207,7 @@ function updateResultListState( newState ) {
 				if( lastBreadcrumb.indexOf(hostname) > -1 ){
 					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + '</li></ol>';
 				} else {
-					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + 
+					breadcrumb = '<ol class="location"><li>' + hostname + 
 						'&nbsp;</li><li>' + lastBreadcrumb + '</li></ol>';
 				}
 			} else {

--- a/src/connector.js
+++ b/src/connector.js
@@ -1200,8 +1200,16 @@ function updateResultListState( newState ) {
 
 			if ( result.raw.hostname && result.raw.displaynavlabel ) {
 				const splittedNavLabel = ( Array.isArray( result.raw.displaynavlabel ) ? result.raw.displaynavlabel[0] : result.raw.displaynavlabel).split( '>' );
-				breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + 
-					'&nbsp;</li><li>' + stripHtml( splittedNavLabel[splittedNavLabel.length-1] ) + '</li></ol>';
+				const hostname = stripHtml( result.raw.hostname );
+				const lastBreadcrumb = stripHtml( splittedNavLabel[splittedNavLabel.length-1] );
+
+				// If the hostname is already part of the breadcrumb, just show the hostname
+				if( lastBreadcrumb.indexOf(hostname) > -1 ){
+					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + '</li></ol>';
+				} else {
+					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + 
+						'&nbsp;</li><li>' + stripHtml( splittedNavLabel[splittedNavLabel.length-1] ) + '</li></ol>';
+				}
 			} else {
 				breadcrumb = '<p class="location"><cite><a href="' + clickUri + '">' + printableUri + '</a></cite></p>';
 			}

--- a/src/connector.js
+++ b/src/connector.js
@@ -1206,7 +1206,7 @@ function updateResultListState( newState ) {
 				// If the hostname is already part of the breadcrumb, just show the hostname
 				breadcrumb = '<ol class="location">';
 				if ( lastBreadcrumb.indexOf(hostname) > -1 ){
-					breadcrumb += '<li>' + stripHtml( result.raw.hostname ) + '</li>';
+					breadcrumb += '<li>' + hostname + '</li>';
 				} else {
 					breadcrumb += '<li>' + hostname + '&nbsp;</li><li>' + lastBreadcrumb + '</li>';
 				}

--- a/src/connector.js
+++ b/src/connector.js
@@ -1204,12 +1204,13 @@ function updateResultListState( newState ) {
 				const lastBreadcrumb = stripHtml( splittedNavLabel[splittedNavLabel.length-1] );
 
 				// If the hostname is already part of the breadcrumb, just show the hostname
-				if( lastBreadcrumb.indexOf(hostname) > -1 ){
-					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + '</li></ol>';
+				breadcrumb = '<ol class="location">';
+				if ( lastBreadcrumb.indexOf(hostname) > -1 ){
+					breadcrumb += '<li>' + stripHtml( result.raw.hostname ) + '</li>';
 				} else {
-					breadcrumb = '<ol class="location"><li>' + hostname + 
-						'&nbsp;</li><li>' + lastBreadcrumb + '</li></ol>';
+					breadcrumb += '<li>' + hostname + '&nbsp;</li><li>' + lastBreadcrumb + '</li>';
 				}
+				breadcrumb += '</ol>';
 			} else {
 				breadcrumb = '<p class="location"><cite><a href="' + clickUri + '">' + printableUri + '</a></cite></p>';
 			}

--- a/src/connector.js
+++ b/src/connector.js
@@ -1208,7 +1208,7 @@ function updateResultListState( newState ) {
 					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + '</li></ol>';
 				} else {
 					breadcrumb = '<ol class="location"><li>' + stripHtml( result.raw.hostname ) + 
-						'&nbsp;</li><li>' + stripHtml( splittedNavLabel[splittedNavLabel.length-1] ) + '</li></ol>';
+						'&nbsp;</li><li>' + lastBreadcrumb + '</li></ol>';
 				}
 			} else {
 				breadcrumb = '<p class="location"><cite><a href="' + clickUri + '">' + printableUri + '</a></cite></p>';


### PR DESCRIPTION
Tickets/Tasks:

- GoC [SR-604: Canada.ca Breadcrumb issue](https://jtickets.atlassian.net/browse/SR-604)
- Coveo [Task 427242](https://dev.azure.com/CoveoPS/ESD%20Canada%20TA%20work/_workitems/edit/427242): SR-604 Canada.ca Breadcrumb issue - Change your address page

Description:

- Addressed an issue where the hostname is duplicated for certain items in the result breadcrumbs

Cause:

- On items with a single breadcrumb pointed to the home page, we replace the scraped breadcrumb with a link to the domain root. .i.e., `<a href="https://www.canada.ca">www.canada.ca</a>`. 
- In the front end search result template, when we build the breadcrumbs, we use the hostname + last breadcrumb. 
- This resulted in the breadcrumbs being repeated on these items. i.e., `canada.ca > www.canada.ca`

Testing:

- You can find affected items by searching for `@numberbreadcrumbs==1` in the Content Browser. Identify an item, then try to bring it up on the search results. Before, you'd see the address repeated: `bst-tsb.gc.ca > www.bst-tsb.gc.ca`. Now, you'll just see the hostname: `bst-tsb.gc.ca`
- Sample searches:
    - "Change your address government/change-address.html"
    -  "Other building finishing contractors - 23839 - Financial performance"
    - "Mycobacterium tuberculosis complex and non-tuberculous mycobacteria"
    - "Webinar transcript: Due diligence in the garment industry"

<img width="1188" height="586" alt="image" src="https://github.com/user-attachments/assets/97bc6a0d-cdb9-4701-be31-e3e7e891f531" />

<img width="1194" height="343" alt="image" src="https://github.com/user-attachments/assets/2efffa85-b66d-4ae3-9e8c-aa8ee80b8030" />
