### PR TITLE
adjust actionCause

### DIFF
--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -235,7 +235,7 @@ function initEngine() {
 	if ( formElement ) {
 		formElement.onsubmit = ( e ) => {
 			e.preventDefault();
-			redirectToSearchPage( 'headerSearchBoxSubmit' );
+			redirectToSearchPage( 'searchFromLink' );
 		};
 	}
 }
@@ -340,7 +340,7 @@ function selectSuggestion() {
 
 		if ( selectedVal ) {
 			searchBoxElement.value = selectedVal;
-			redirectToSearchPage( 'headerSearchBoxSuggestion' );
+			redirectToSearchPage( 'omniboxFromLink' );
 		}
 	}
 }
@@ -418,7 +418,7 @@ function updateSearchBoxState( newState ) {
 			};
 			node.onclick = ( e ) => {
 				searchBoxElement.value = stripHtml( e.currentTarget.innerText );
-				redirectToSearchPage( 'headerSearchBoxSuggestion' );
+				redirectToSearchPage( 'omniboxFromLink' );
 			};
 			node.innerHTML = DOMPurify.sanitize( suggestion.highlightedValue );
 			suggestionsElement.appendChild( node );


### PR DESCRIPTION
Adjust actionCause from the header search box to use one of the allowed values

TEST CASE 1 - search using query suggestions
1- Open a test page with header search box suggestions enabled
2- Perform a search by typing in the search box and then clicking an items in the suggestions
3- Confirm that you are forwarded to the search results page with ?actionCause=omniboxFromLink 

TEST CASE 2 - search using enter
1- Open a test page with header search box suggestions enabled
2- Perform a search by typing in the search box and then hit enter
3- Confirm that you are forwarded to the search results page with ?actionCause=searchFromLink 

TEST CASE 3 - search using search button
1- Open a test page with header search box suggestions enabled
2- Perform a search by typing in the search box and then click the search button (magnifier)
3- Confirm that you are forwarded to the search results page with ?actionCause=searchFromLink 