### PR TITLE
Top-Right QS: Small Updates

### DIFF
--- a/src/connector.css
+++ b/src/connector.css
@@ -44,9 +44,9 @@
 	width: calc(100% - 30px);
 }
 
-@media screen and (max-width: 991px) {
+@media screen and (max-width: 767px) {
 	#wb-bnr .query-suggestions {
-		position: relative;
+		position: static;
 		width: 100%;
 	}
 }

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -115,6 +115,11 @@ function initTpl() {
 		// default searchbox attributes
 		searchBoxElement.setAttribute( 'type', 'search' ); // default, when query suggestions are disabled
 
+		// remove legacy list attribute if exists
+		if ( searchBoxElement.hasAttribute( 'list' ) ) {
+			searchBoxElement.removeAttribute( 'list' );
+		}
+
 		// if query suggestions are enabled and not advanced search, auto-create suggestions element and update searchbox attributes
 		if ( params.numberOfSuggestions > 0 && !suggestionsElement ) {
 			searchBoxElement.setAttribute( 'type', 'text' );


### PR DESCRIPTION
TR-01: Fix media queries (767px instead of 991px) for Position: static on the ul#suggestions

TR-02: Remove list attribute on the Combobox input to avoid confusion with screen readers (long-term solution is through the Header AEM)

TEST CASE 1
1- Open Chrome or Edge developer tools and click the device toolbar (Ctrl + Shift + M)
2- type a few letters in the header search box so that the suggestions appears
3- Resize horizontally and make sure the layout adjust to mobile view at 767px

TEST CASE 2
1- Open the search page with a header search box
2- make sure the 'list' attribute is removed on the input box of the header search box  