### PR TITLE
add trigger custom click event

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -13,6 +13,7 @@ import {
 	buildNotifyTrigger,
 	loadAdvancedSearchQueryActions,
 	loadSortCriteriaActions,
+	loadGenericAnalyticsActions,
 	HighlightUtils
 } from './headless.esm.js';
 
@@ -1314,6 +1315,18 @@ function updateNotifyTriggerState ( newState ) {
 
 	if ( notificationState.notifications?.length ) {
 		notificationTriggerElement.innerHTML = notificationTriggerTemplateHTML.replace( "%[notification]", DOMPurify.sanitize( notificationState.notifications[0] ) );
+		notificationTriggerElement.onclick = ( elemClicked ) => {
+			if ( elemClicked.target.tagName.toLowerCase() === 'a' ) {
+				const { logCustomEvent } = loadGenericAnalyticsActions( headlessEngine );
+				const payload = {
+					type: 'queryPipelineNotificationTrigger',
+					meta: { 'triggerLinkUrl': elemClicked.target?.href },
+					evt: 'click'
+				};
+
+				headlessEngine.dispatch( logCustomEvent( payload ) );
+			}
+		};
 		focusToView();
 	}
 	else {


### PR DESCRIPTION
TEST CASE 1 : 
- Perform a search that fires a trigger (like 'signin')
- Make sure the trigger is displayed at the top of the results page
- click on a link in the trigger and make sure a custom event is sent at that moment using Chrome debug/network tool
- validate the event from the visit browser 