### PR TITLE
Bugfix:  Query suggestions only work after more than 3 characters are typed and a character is deleted

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -964,10 +964,16 @@ function initEngine() {
 	if ( searchBoxElement ) {
 		searchBoxElement.onkeydown = ( e ) => {
 			// Enter
-			if ( e.keyCode === 13 && ( activeSuggestion !== 0 && suggestionsElement && !suggestionsElement.hidden ) ) {
-				selectSuggestion();
-				closeSuggestionsBox();
-				e.preventDefault();
+			if ( e.keyCode === 13 ) {
+
+				// Save that the last input change came from the Enter key so QS doesn't reopen after a search is submitted
+				lastCharKeyUp = 13;
+
+				if ( activeSuggestion !== 0 && suggestionsElement && !suggestionsElement.hidden ) {
+					selectSuggestion();
+					closeSuggestionsBox();
+					e.preventDefault();
+				}
 			}
 			// Escape or Tab
 			else if ( e.keyCode === 27 || e.keyCode === 9 ) {
@@ -993,16 +999,14 @@ function initEngine() {
 				}
 			}
 		};
-		searchBoxElement.onkeyup = ( e ) => {
+		searchBoxElement.onkeyup = () => {
 			waitForkeyUp = false;
-			lastCharKeyUp = e.keyCode;
-			// Keys that don't changes the input value
-			if ( ( e.key.length !== 1 && e.keyCode !== 46 && e.keyCode !== 8 ) ||                       // Non-printable char except Delete or Backspace
-				( e.ctrlKey && e.key !== "x" && e.key !== "X" && e.key !== "v" && e.key !== "V" ) ) {   // Ctrl-key is pressed but not X or V is use 
-				return;
-			}
+		};
 
-			// Any other key
+		// Use the "input" events to detect text changes (better support across devices, e.g., Android)
+		searchBoxElement.oninput = ( e ) => {
+			lastCharKeyUp = null;
+
 			if ( searchBoxController.state.value !== e.target.value ) {
 				searchBoxController.updateText( stripHtml( e.target.value ) );
 			}

--- a/src/suggestions.js
+++ b/src/suggestions.js
@@ -180,10 +180,16 @@ function initEngine() {
 	if ( searchBoxElement ) {
 		searchBoxElement.onkeydown = ( e ) => {
 			// Enter
-			if ( e.keyCode === 13 && ( activeSuggestion !== 0 && suggestionsElement && !suggestionsElement.hidden ) ) {
-				selectSuggestion();
-				closeSuggestionsBox();
-				e.preventDefault();
+			if ( e.keyCode === 13 ) {
+
+				// Save that the last input change came from the Enter key so QS doesn't reopen after a search is submitted
+				lastCharKeyUp = 13;
+
+				if ( activeSuggestion !== 0 && suggestionsElement && !suggestionsElement.hidden ) {
+					selectSuggestion();
+					closeSuggestionsBox();
+					e.preventDefault();
+				}
 			}
 			// Escape or Tab
 			else if ( e.keyCode === 27 || e.keyCode === 9 ) {
@@ -209,16 +215,14 @@ function initEngine() {
 				}
 			}
 		};
-		searchBoxElement.onkeyup = ( e ) => {
+		searchBoxElement.onkeyup = () => {
 			waitForkeyUp = false;
-			lastCharKeyUp = e.keyCode;
-			// Keys that don't changes the input value
-			if ( ( e.key.length !== 1 && e.keyCode !== 46 && e.keyCode !== 8 ) ||                       // Non-printable char except Delete or Backspace
-				( e.ctrlKey && e.key !== "x" && e.key !== "X" && e.key !== "v" && e.key !== "V" ) ) {   // Ctrl-key is pressed but not X or V is use 
-				return;
-			}
+		};
 
-			// Any other key
+		// Use the "input" events to detect text changes (better support across devices, e.g., Android)
+		searchBoxElement.oninput = ( e ) => {
+			lastCharKeyUp = null;
+
 			if ( e.target.value ) {
 				updateSearchBoxText( sanitizeQuery( e.target.value ) );
 			}


### PR DESCRIPTION
## Description

- Fix for Query Suggestions on Android. 
- Uses `Input` events rather that `Keyboard` events to better detect typing. 
- Fixes for both the "top right" search QS and the main search QS

## Details

- Input events more reliable across devices
- Tightened up logic around "enter" key

## Azure DevOps Work Item(s)

- [Defect 447196](https://dev.azure.com/CoveoPS/ESD%20Canada%20TA%20work/_workitems/edit/447196): Query Suggestions - MOBILE ONLY Query suggestions only work after more than 3 characters are typed and a character is deleted

## Test Cases

Pre-requisite
- Deploy the search UI to a URL you can browse in mobile. If using Android Studio to test, you can access `localhost` at `10.0.2.2`

Top right search
1. Load the top right search in mobile (Android)
2. Type 3 letters into the search. For example, `can`
    - Query suggestion should appear
3. Backspace
    - Query suggestion should disappear
4. Type a different letter. i.e., `r` to make the query `car`
    - Query suggestion should appear again and be different

Basic search
1. Load the basic search UI in mobile (Android)
2. Repeat the same process as above

